### PR TITLE
Fix for 'if' statement

### DIFF
--- a/src/compiler.c
+++ b/src/compiler.c
@@ -365,6 +365,8 @@ static inline void compile_if_stmt(Compiler *comp, RakChunk *chunk, uint16_t *of
   if (!rak_is_ok(err)) return;
   uint32_t instr = rak_jump_if_false_instr((uint16_t) chunk->instrs.len);
   patch_instr(chunk, jump1, instr);
+  if (!rak_is_ok(err)) return;
+  emit_instr(chunk, rak_pop_instr(), err);
   uint16_t _off;
   compile_if_stmt_cont(comp, chunk, &_off, err);
   if (!rak_is_ok(err)) return;
@@ -378,17 +380,14 @@ static inline void compile_if_stmt_cont(Compiler *comp, RakChunk *chunk, uint16_
 {
   if (!match(comp, RAK_TOKEN_KIND_ELSE_KW))
   {
-    emit_instr(chunk, rak_pop_instr(), err);
-    if (!rak_is_ok(err)) return;
     *off = (uint16_t) chunk->instrs.len;
     return;
   }
   next(comp, err);
   if (match(comp, RAK_TOKEN_KIND_IF_KW))
   {
-    emit_instr(chunk, rak_pop_instr(), err);
-    if (!rak_is_ok(err)) return;
     compile_if_stmt(comp, chunk, off, err);
+    *off = (uint16_t) chunk->instrs.len;
     return;
   }
   if (!match(comp, RAK_TOKEN_KIND_LBRACE))

--- a/tests/statements.if.yaml
+++ b/tests/statements.if.yaml
@@ -1,0 +1,89 @@
+- test: if else / if let statement (1)
+  source: |
+    let a=10;
+    let b=20;
+    if a < 0 { println("a < 0 is true"); } else { println("a < 0 is false"); }
+    if let c=444; b > 0 { print("b > 0 is true and c is "); println(c); }
+  out: |
+    a < 0 is false
+    b > 0 is true and c is 444
+
+- test: if else / if let statement (2)
+  source: |
+    let a=-10;
+    let b=20;
+    if a < 0 { println("a < 0 is true"); } else { println("a < 0 is false"); }
+    if let c=444; b > 0 { print("b > 0 is true and c is "); println(c); }
+  out: |
+    a < 0 is true
+    b > 0 is true and c is 444
+
+- test: else if let statement
+  source: |
+    let a=10;
+    let b=20;
+    print(a); print(" "); println(b);
+    if let a=666; b < 0 { print("b < 0 is true. Local a is "); println(a); } else if let a = 777; b > 0 { print("b < 0 is false and b > 0 is true. Local a is "); println(a); }
+    &a=-10;&b=-20;
+    print(a); print(" "); println(b);
+    if let a=666; b < 0 { print("b < 0 is true. Local a is "); println(a); } else if let a = 777; b > 0 { print("b < 0 is false and b > 0 is true. Local a is "); println(a); }
+    print(a); print(" "); println(b);
+  out: |
+    10 20
+    b < 0 is false and b > 0 is true. Local a is 777
+    -10 -20
+    b < 0 is true. Local a is 666
+    -10 -20
+
+
+- test: All if else let statements
+  source: |
+    let a=10;
+    let b=20;
+
+    print("a="); print(a); print(" :: b="); println(b); 
+    if a > 0 { println(" 5. a > 0 is true"); }
+    if a < 0 { println(" 6. a < 0 is true"); } else { println(" 6. a < 0 is false"); }
+    if a < 0 { println(" 7. a < 0 is true"); } else if b > 0 { println(" 7. a < 0 is false and b > 0 is true"); }
+    if let a=444; b > 0 { print(" 8. b > 0 is true and local a is "); println(a); }
+    if let a=555; b < 0 { println(" 9. b < 0 is true"); } else { print(" 9. b < 0 is false. Local a is "); println(a); }
+    if let a=666; b < 0 { println("10. b < 0 is true"); } else if let a = 777; b > 0 { print("10. b < 0 is false and b > 0 is true. Local a is "); println(a); } else { print("10. b = 0. Local a is "); println(a); }
+
+    &a=-10;&b=-20;
+    print("a="); print(a); print(" :: b="); println(b); 
+    if a > 0 { println("14. a > 0 is true"); }
+    if a < 0 { println("15. a < 0 is true"); } else { println("15. a < 0 is false"); }
+    if a < 0 { println("16. a < 0 is true"); } else if b > 0 { println("16. a < 0 is false and b > 0 is true"); }
+    if let a=444; b > 0 { print("17. b > 0 is true and local a is "); println(a); }
+    if let a=555; b < 0 { println("18. b < 0 is true"); } else { print("18. b < 0 is false. Local a is "); println(a); }
+    if let a=666; b < 0 { println("19. b < 0 is true"); } else if let a = 777; b > 0 { print("19. b < 0 is false and b > 0 is true. Local a is "); println(a); } else { print("19. b = 0. Local a is "); println(a); }
+
+    &a=10;&b=0;
+    print("a="); print(a); print(" :: b="); println(b); 
+    if a > 0 { println("23. a > 0 is true"); }
+    if a < 0 { println("24. a < 0 is true"); } else { println("24. a < 0 is false"); }
+    if a < 0 { println("25. a < 0 is true"); } else if b > 0 { println("25. a < 0 is false and b > 0 is true"); }
+    if let a=444; b > 0 { print("26. b > 0 is true and local a is "); println(a); }
+    if let a=555; b < 0 { println("27. b < 0 is true"); } else { print("27. b < 0 is false. Local a is "); println(a); }
+    if let a=666; b < 0 { println("28. b < 0 is true"); } else if let a = 777; b > 0 { print("28. b < 0 is false and b > 0 is true. Local a is "); println(a); } else { print("28. b = 0. Local a is "); println(a); }
+
+    print("a="); print(a); print(" :: b="); println(b);
+  out: |
+    a=10 :: b=20
+     5. a > 0 is true
+     6. a < 0 is false
+     7. a < 0 is false and b > 0 is true
+     8. b > 0 is true and local a is 444
+     9. b < 0 is false. Local a is 555
+    10. b < 0 is false and b > 0 is true. Local a is 777
+    a=-10 :: b=-20
+    15. a < 0 is true
+    16. a < 0 is true
+    18. b < 0 is true
+    19. b < 0 is true
+    a=10 :: b=0
+    23. a > 0 is true
+    24. a < 0 is false
+    27. b < 0 is false. Local a is 555
+    28. b = 0. Local a is 777
+    a=10 :: b=0


### PR DESCRIPTION
## 1. Missing 'pop' instuction in 'else' block.
 Running this test case:
```
let a=10;
let b=20;
if a < 0 { println("a < 0 is true"); } else { println("a < 0 is false"); }
if let c=444; b > 0 { print("b > 0 is true and c is "); println(c); }
```
The output was wrong when the first branch took the 'else' path. Found that is was missing a 'pop' instruction. Adding it solves this problem.
```diff
diff --git a/src/compiler.c b/src/compiler.c
index 34538b0..66aa134 100644
--- a/src/compiler.c
+++ b/src/compiler.c
@@ -396,6 +396,8 @@ static inline void compile_if_stmt_cont(Compiler *comp, RakChunk *chunk, uint16_
     expected_token_error(err, RAK_TOKEN_KIND_LBRACE, comp->lex.tok);
     return;
   }
+  emit_instr(chunk, rak_pop_instr(), err);
+  if (!rak_is_ok(err)) return;
   compile_block(comp, chunk, err);
   if (!rak_is_ok(err)) return;
   *off = (uint16_t) chunk->instrs.len;
```
But, for simplicity, it is better to add this instruction in the  function `compile_if_stmt`, because all paths of function `compile_if_stmt_cont` were doing the same code. Also the 'pop' for the true path was there, so it makes sense to add the 'pop' for the false path in same function.
```diff
diff --git a/src/compiler.c b/src/compiler.c
index 34538b0..ece720d 100644
--- a/src/compiler.c
+++ b/src/compiler.c
@@ -365,6 +365,8 @@ static inline void compile_if_stmt(Compiler *comp, RakChunk *chunk, uint16_t *of
   if (!rak_is_ok(err)) return;
   uint32_t instr = rak_jump_if_false_instr((uint16_t) chunk->instrs.len);
   patch_instr(chunk, jump1, instr);
+  emit_instr(chunk, rak_pop_instr(), err);
+  if (!rak_is_ok(err)) return;
   uint16_t _off;
   compile_if_stmt_cont(comp, chunk, &_off, err);
   if (!rak_is_ok(err)) return;
@@ -378,16 +380,12 @@ static inline void compile_if_stmt_cont(Compiler *comp, RakChunk *chunk, uint16_
 {
   if (!match(comp, RAK_TOKEN_KIND_ELSE_KW))
   {
-    emit_instr(chunk, rak_pop_instr(), err);
-    if (!rak_is_ok(err)) return;
     *off = (uint16_t) chunk->instrs.len;
     return;
   }
   next(comp, err);
   if (match(comp, RAK_TOKEN_KIND_IF_KW))
   {
-    emit_instr(chunk, rak_pop_instr(), err);
-    if (!rak_is_ok(err)) return;
     compile_if_stmt(comp, chunk, off, err);
     return;
   }
```

## 2. Wrong 'pop' in 'else if'
In another test case, strange behavior in `else if`. If the statement was changed to ` else { if ... }`, no problem was found.
```
let a=10;
let b=20;

&a=-10;&b=-20;
print("    a="); print(a); print(" :: b="); println(b); 
if let a=666; b < 0 { println("19. b < 0 is true"); } else if let a = 777; b > 0 { print("19. b < 0 is false and b > 0 is true. Local a is "); println(a); }
print("    a="); print(a); print(" :: b="); println(b); 
```

Found that it the instruction length was not updated for this code. This fixes:
```diff
diff --git a/src/compiler.c b/src/compiler.c
index 34538b0..287e346 100644
--- a/src/compiler.c
+++ b/src/compiler.c
@@ -389,6 +389,7 @@ static inline void compile_if_stmt_cont(Compiler *comp, RakChunk *chunk, uint16_
     emit_instr(chunk, rak_pop_instr(), err);
     if (!rak_is_ok(err)) return;
     compile_if_stmt(comp, chunk, off, err);
+    *off = (uint16_t) chunk->instrs.len;
     return;
   }
   if (!match(comp, RAK_TOKEN_KIND_LBRACE))
```
