### PR TITLE
Script to generate test coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .trash/
 .vscode/
 build/
+coverage/

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Now you can run the tests:
 ./tests.sh
 ```
 
+To generate a test coverage report in Linux, run the `test-coverage.sh` file. You'll need at least one of the coverage tools: 'lcov' or 'gcovr'. After running the script, it will display the location of the generated HTML report
+
 ## Cleaning
 
 To clean the build files, run the clean script:

--- a/test-coverage.sh
+++ b/test-coverage.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+./clean.sh
+
+cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="--coverage"
+cmake --build build
+
+./test.sh -q
+
+mkdir -p coverage
+rm -Rf coverage/*
+
+if command -v lcov &> /dev/null; then
+    lcov --capture --directory . --output-file coverage/coverage.info
+    genhtml coverage/coverage.info --output-directory coverage/lcov_report
+    echo "Coverage report generated with 'lcov': coverage/lcov_report/index.html"
+elif command -v gcovr &> /dev/null; then
+    gcovr -r . --html --html-details -o coverage/coverage_report.html
+    echo "Coverage report generated with 'gcovr': coverage/coverage_report.html"
+else
+    echo "Error: Neither 'lcov' nor 'gcovr' is installed."
+    echo "Please install one of them to run 'test-coverage' again."
+    exit 1
+fi


### PR DESCRIPTION
Following @fabiosvm efforts to add test coverage in codacy.com, it is presented a script to generate the report locally. I like to use 'gcovr', while the option used for codacy.com is 'lcov'. Both options were added, so the script will pick one available.

Generating report for Windows was not implemented.