### PR TITLE
Fix: buffer overflow in  rak_builtin_resolve_global

### DIFF
--- a/src/builtin.c
+++ b/src/builtin.c
@@ -695,8 +695,10 @@ int rak_builtin_resolve_global(int len, char *chars)
   for (int i = 0; i < n; ++i)
   {
     const char *cstr = globals[i];
-    // FIX: Buffer overflow.
-    if (!memcmp(cstr, chars, len) && !cstr[len])
+    if (
+      (int)strlen(cstr) == len
+      && !memcmp(cstr, chars, len)
+    )
       return i;
   }
   return -1;


### PR DESCRIPTION
The call to `memcmp(cstr, chars, len)` was reaching beyond limits of `chars`. Checking if the length of builtin matches the length of incoming chars ensures that comparision will always be within buffer limits.

Many testcases were reaching this overflow when compile option '-fsanitize=address' was used, so no need new testcases.