### PR TITLE
Fix: missing memfree in sucessfull compilation

### DIFF
--- a/src/compiler.c
+++ b/src/compiler.c
@@ -1675,6 +1675,8 @@ RakClosure *rak_compile(RakString *file, RakString *source, RakError *err)
   if (!rak_is_ok(err)) goto fail;
   RakClosure *cl = rak_closure_new(RAK_CALLABLE_TYPE_FUNCTION,
     &comp.fn->callable, err);
+  rak_lexer_deinit(&lex);
+  compiler_deinit(&comp);
   if (rak_is_ok(err)) return cl;
 fail:
   rak_lexer_deinit(&lex);

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -1675,9 +1675,10 @@ RakClosure *rak_compile(RakString *file, RakString *source, RakError *err)
   if (!rak_is_ok(err)) goto fail;
   RakClosure *cl = rak_closure_new(RAK_CALLABLE_TYPE_FUNCTION,
     &comp.fn->callable, err);
+  if (!rak_is_ok(err)) goto fail;
   rak_lexer_deinit(&lex);
   compiler_deinit(&comp);
-  if (rak_is_ok(err)) return cl;
+  return cl;
 fail:
   rak_lexer_deinit(&lex);
   compiler_deinit(&comp);


### PR DESCRIPTION
Fix memory leak when successful compilation ends. The code was already done for failed compilation, but missing for the success.

Most of testcases were indicating memory leak when compile option '-fsanitize=address' was used, so no need new testcases.