### PR TITLE
Fix: buffer overflow in match_keyword

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -267,7 +267,9 @@ static inline bool match_keyword(RakLexer *lex, const char *kw, RakTokenKind kin
 {
   int len = (int) strlen(kw);
   if (lex->curr + len - lex->source->slice.data > lex->source->slice.len
-   || memcmp(lex->curr, kw, len))
+   || memcmp(lex->curr, kw, len)
+   || (isalnum(char_at(lex, len)))
+   || (char_at(lex, len) == '_'))
     return false;
   lex->tok = token(lex, kind, len, lex->curr);
   next_chars(lex, len);

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -266,9 +266,8 @@ static inline bool match_string(RakLexer *lex, RakError *err)
 static inline bool match_keyword(RakLexer *lex, const char *kw, RakTokenKind kind)
 {
   int len = (int) strlen(kw);
-  if (memcmp(lex->curr, kw, len)
-   || (isalnum(char_at(lex, len)))
-   || (char_at(lex, len) == '_'))
+  if (lex->curr + len - lex->source->slice.data > lex->source->slice.len
+   || memcmp(lex->curr, kw, len))
     return false;
   lex->tok = token(lex, kind, len, lex->curr);
   next_chars(lex, len);

--- a/tests/compiler.misc.yaml
+++ b/tests/compiler.misc.yaml
@@ -120,3 +120,10 @@
   out:
     regex: "too many local variables"
   exit_code: 1
+
+- test: Variables names starting with keywords
+  source: |
+    let ifa=1;
+    let let_;
+    &let_=ifa;
+  out: ""


### PR DESCRIPTION
The call of `memcmp(lex->curr, kw, len)` was reaching beyond limits of `lex->curr` in some cases. Added a rule to check if the length of remaining chars in `lex->curr` is greater than or equal the `len`. This ensures the 'memcmp' function will never reach buffer overflow. It was also removed some code that was not needed for this comparison.

Many testcases were reaching this overflow when compile option '-fsanitize=address' was used, so no need new testcases.