### PR TITLE
Update RakToken to allow RakValue

### DIFF
--- a/include/rak/lexer.h
+++ b/include/rak/lexer.h
@@ -75,6 +75,7 @@ typedef struct
   int           col;
   int           len;
   char         *chars;
+  RakValue      val;
 } RakToken;
 
 typedef struct

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -1278,13 +1278,10 @@ static inline void compile_prim_expr(Compiler *comp, RakChunk *chunk, RakError *
   {
     RakToken tok = comp->lex->tok;
     next(comp, err);
-    RakString *str = rak_string_new_from_cstr(tok.len, tok.chars, err);
-    if (!rak_is_ok(err)) return;
-    RakValue val = rak_string_value(str);
-    uint8_t idx = rak_chunk_append_const(chunk, val, err);
+    uint8_t idx = rak_chunk_append_const(chunk, tok.val, err);
     if (!rak_is_ok(err))
     {
-      rak_string_free(str);
+      rak_value_free(tok.val);
       return;
     }
     emit_instr(chunk, rak_load_const_instr(idx), err);

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -10,6 +10,7 @@
 
 #include "rak/lexer.h"
 #include "rak/string.h"
+#include "rak/value.h"
 #include <ctype.h>
 #include <string.h>
 
@@ -29,7 +30,7 @@ static bool parse_string(RakLexer *lex, RakError *err);
 static inline bool match_string(RakLexer *lex, RakError *err);
 static inline bool match_keyword(RakLexer *lex, const char *kw, RakTokenKind kind);
 static inline bool match_ident(RakLexer *lex);
-static inline RakToken token(RakLexer *lex, RakTokenKind kind, int len, char *chars);
+static inline RakToken token(RakLexer *lex, RakTokenKind kind, int len, char *chars, RakValue val);
 static inline void unexpected_character_error(RakError *err, char c, int ln, int col);
 
 static inline void skip_whitespace_comments(RakLexer *lex)
@@ -75,7 +76,7 @@ static inline void next_chars(RakLexer *lex, int len)
 static inline bool match_char(RakLexer *lex, char c, RakTokenKind kind)
 {
   if (current_char(lex) != c) return false;
-  lex->tok = token(lex, kind, 1, lex->curr);
+  lex->tok = token(lex, kind, 1, lex->curr, rak_nil_value());
   next_char(lex);
   return true;
 }
@@ -85,7 +86,7 @@ static inline bool match_chars(RakLexer *lex, const char *chars, RakTokenKind ki
   int len = (int) strlen(chars);
   if (memcmp(lex->curr, chars, len))
     return false;
-  lex->tok = token(lex, kind, len, lex->curr);
+  lex->tok = token(lex, kind, len, lex->curr, rak_nil_value());
   next_chars(lex, len);
   return true;
 }
@@ -128,7 +129,7 @@ static inline bool match_number(RakLexer *lex, RakError *err)
     return false;
   }
 end:
-  lex->tok = token(lex, RAK_TOKEN_KIND_NUMBER, len, lex->curr);
+  lex->tok = token(lex, RAK_TOKEN_KIND_NUMBER, len, lex->curr, rak_nil_value());
   next_chars(lex, len);
   return true;
 }
@@ -223,7 +224,7 @@ static bool parse_string(RakLexer *lex, RakError *err)
       rak_error_set(err, "unterminated string at %d,%d", lex->ln, lex->col);
       return false;
     case '\"':
-      lex->tok = token(lex, RAK_TOKEN_KIND_STRING, rak_string_len(text), rak_string_chars(text));
+      lex->tok = token(lex, RAK_TOKEN_KIND_STRING, -1, NULL, rak_string_value(text));
       next_char(lex);
       return true;
     case '\\':
@@ -253,7 +254,7 @@ static inline bool match_keyword(RakLexer *lex, const char *kw, RakTokenKind kin
    || (isalnum(char_at(lex, len)))
    || (char_at(lex, len) == '_'))
     return false;
-  lex->tok = token(lex, kind, len, lex->curr);
+  lex->tok = token(lex, kind, len, lex->curr, rak_nil_value());
   next_chars(lex, len);
   return true;
 }
@@ -265,19 +266,20 @@ static inline bool match_ident(RakLexer *lex)
   int len = 1;
   while (isalnum(char_at(lex, len)) || char_at(lex, len) == '_')
     ++len;
-  lex->tok = token(lex, RAK_TOKEN_KIND_IDENT, len, lex->curr);
+  lex->tok = token(lex, RAK_TOKEN_KIND_IDENT, len, lex->curr, rak_nil_value());
   next_chars(lex, len);
   return true;
 }
 
-static inline RakToken token(RakLexer *lex, RakTokenKind kind, int len, char *chars)
+static inline RakToken token(RakLexer *lex, RakTokenKind kind, int len, char *chars, RakValue val)
 {
   return (RakToken) {
     .kind = kind,
     .ln = lex->ln,
     .col = lex->col,
     .len = len,
-    .chars = chars
+    .chars = chars,
+    .val = val
   };
 }
 


### PR DESCRIPTION
In order to allow RakString in parse_string to be passed as token, a new field must be created. When data is from source code, then token len and chars to be used, and rak_nil_value() is passed as val. If the data is already allocated, then it is passed len as -1 and chars as NULL.