### PR TITLE
fix: memory leak in unpack_fields

### DIFF
--- a/include/rak/vm.h
+++ b/include/rak/vm.h
@@ -755,11 +755,13 @@ static inline void rak_vm_unpack_fields(RakFiber *fiber, uint8_t n, RakError *er
     {
       rak_error_set(err, "record has no field named '%.*s'",
         rak_string_len(name), rak_string_chars(name));
+      // Fix: heap-use-after-free if error is not the first field in destructuring.
       return;
     }
     RakValue _val = rak_record_get(rec, idx).val;
     slots[i] = _val;
     rak_value_retain(_val);
+    rak_string_release(name);
   }
   rak_stack_pop(&fiber->vstk);
   rak_record_release(rec);

--- a/include/rak/vm.h
+++ b/include/rak/vm.h
@@ -16,6 +16,7 @@
 #include <math.h>
 #include "range.h"
 #include "record.h"
+#include "value.h"
 
 static inline void rak_vm_push(RakFiber *fiber, RakValue val, RakError *err);
 static inline void rak_vm_push_nil(RakFiber *fiber, RakError *err);
@@ -755,8 +756,9 @@ static inline void rak_vm_unpack_fields(RakFiber *fiber, uint8_t n, RakError *er
     {
       rak_error_set(err, "record has no field named '%.*s'",
         rak_string_len(name), rak_string_chars(name));
-      // Fix: heap-use-after-free if error is not the first field in destructuring.
-      return;
+      slots[i] = rak_nil_value();
+      rak_string_release(name);
+      continue;
     }
     RakValue _val = rak_record_get(rec, idx).val;
     slots[i] = _val;

--- a/tests/destructuring.yaml
+++ b/tests/destructuring.yaml
@@ -27,6 +27,15 @@
     2
     3
 
+- test: destruct record (with value retain)
+  source: |
+    let {y, z} = {x: 1, y: 2, z: "asdf"};
+    println(y);
+    println(z);
+  out: |
+    2
+    asdf
+
 - test: destruct record (error)
   source: |
     let {y, name} = {x: 1, y: 2, z: 3};
@@ -46,4 +55,11 @@
     let {z, name, y} = {x: 1, y: 2, z: 3};
   out:
     regex: "record has no field named"
+  exit_code: 1
+
+- test: destruct record (error) (4)
+  source: |
+    let {z, name, y} = [ 1, 2, 3, 4];
+  out:
+    regex: "cannot unpack fields from value of type"
   exit_code: 1

--- a/tests/destructuring.yaml
+++ b/tests/destructuring.yaml
@@ -33,3 +33,17 @@
   out:
     regex: "record has no field named"
   exit_code: 1
+
+- test: destruct record (error) (2)
+  source: |
+    let {name, y} = {x: 1, y: 2, z: 3};
+  out:
+    regex: "record has no field named"
+  exit_code: 1
+
+- test: destruct record (error) (3)
+  source: |
+    let {z, name, y} = {x: 1, y: 2, z: 3};
+  out:
+    regex: "record has no field named"
+  exit_code: 1


### PR DESCRIPTION
The name of variables to be used in unpack_fields was being referenced twice: one on load instruction, another in unpack_fields instruction. Releasing the RakString when destructuring a record decrements the refCount, so it is used as planned.

But this introduced a second bug: when the error occurs not in the first field, then the RakString is freed twice in `rak_fiber_deinit`: one when it was in the vstk, and another in `release_consts`. When refCount is accessed, heap use after free is triggered and the program is terminated. Good news is that the error is already printed and the program was going to end with error anyway.