### PR TITLE
Moving string escapes parsing to string file.

### DIFF
--- a/include/rak/string.h
+++ b/include/rak/string.h
@@ -48,5 +48,7 @@ void rak_string_inplace_clear(RakString *str);
 bool rak_string_equals(RakString *str1, RakString *str2);
 int rak_string_compare(RakString *str1, RakString *str2);
 void rak_string_print(RakString *str);
+void rak_string_init_from_cstr_with_escapes(RakString *str, int len, const char *cstr, RakError *err);
+RakString *rak_string_new_from_cstr_with_escapes(int len, const char *cstr, RakError *err);
 
 #endif // RAK_STRING_H

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -13,6 +13,7 @@
 #include "rak/builtin.h"
 #include "rak/function.h"
 #include "rak/lexer.h"
+#include "rak/string.h"
 
 #define match(c, t) ((c)->lex->tok.kind == (t))
 
@@ -1282,7 +1283,7 @@ static inline void compile_prim_expr(Compiler *comp, RakChunk *chunk, RakError *
   {
     RakToken tok = comp->lex->tok;
     next(comp, err);
-    RakString *str = rak_string_new_from_cstr(tok.len, tok.chars, err);
+    RakString *str = rak_string_new_from_cstr_with_escapes(tok.len, tok.chars, err);
     if (!rak_is_ok(err)) return;
     RakValue val = rak_string_value(str);
     uint8_t idx = rak_chunk_append_const(chunk, val, err);

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -23,7 +23,7 @@ static inline void next_chars(RakLexer *lex, int len);
 static inline bool match_char(RakLexer *lex, char c, RakTokenKind kind);
 static inline bool match_chars(RakLexer *lex, const char *chars, RakTokenKind kind);
 static inline bool match_number(RakLexer *lex, RakError *err);
-static void check_string(RakLexer *lex, RakError *err);
+static bool check_string(RakLexer *lex, RakError *err);
 static inline bool match_string(RakLexer *lex, RakError *err);
 static inline bool match_keyword(RakLexer *lex, const char *kw, RakTokenKind kind);
 static inline bool match_ident(RakLexer *lex);
@@ -147,7 +147,7 @@ end:
   return true;
 }
 
-static void check_string(RakLexer *lex, RakError *err)
+static bool check_string(RakLexer *lex, RakError *err)
 {
   bool isEscape = false;
   char *cstrStart = lex->curr;
@@ -158,7 +158,7 @@ static void check_string(RakLexer *lex, RakError *err)
     case '\0':
     case '\n':
       rak_error_set(err, "unterminated string at %d,%d", lex->ln, lex->col);
-      return;
+      return false;
     case '\"':
       if (isEscape)
       {
@@ -168,7 +168,7 @@ static void check_string(RakLexer *lex, RakError *err)
       }
       lex->tok = token(lex, RAK_TOKEN_KIND_STRING, (int)(lex->curr - cstrStart), cstrStart);
       next_char(lex);
-      return;
+      return true;
     case '\\':
       isEscape = true;
       next_char(lex);
@@ -185,8 +185,7 @@ static inline bool match_string(RakLexer *lex, RakError *err)
 {
   if (current_char(lex) != '\"') return false;
   next_char(lex);
-  check_string(lex, err);
-  return true;
+  return check_string(lex, err);
 }
 
 static inline bool match_keyword(RakLexer *lex, const char *kw, RakTokenKind kind)

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -23,10 +23,7 @@ static inline void next_chars(RakLexer *lex, int len);
 static inline bool match_char(RakLexer *lex, char c, RakTokenKind kind);
 static inline bool match_chars(RakLexer *lex, const char *chars, RakTokenKind kind);
 static inline bool match_number(RakLexer *lex, RakError *err);
-static inline unsigned char hex2bin (char c);
-static bool handle_hex_escape(RakLexer *lex, RakString *text, RakError *err);
-static bool handle_escape_sequence(RakLexer *lex, RakString *text, RakError *err);
-static bool parse_string(RakLexer *lex, RakError *err);
+static void check_string(RakLexer *lex, RakError *err);
 static inline bool match_string(RakLexer *lex, RakError *err);
 static inline bool match_keyword(RakLexer *lex, const char *kw, RakTokenKind kind);
 static inline bool match_ident(RakLexer *lex);
@@ -150,87 +147,10 @@ end:
   return true;
 }
 
-static inline unsigned char hex2bin (char c)
+static void check_string(RakLexer *lex, RakError *err)
 {
-  if (c >= '0' && c <= '9')
-    return c - '0' ;
-  if (c >= 'A' && c <= 'F')
-    return c - 'A' + 10 ;
-  if (c >= 'a' && c <= 'f')
-    return c - 'a' + 10 ;
-  return 0;
-}
-
-static bool handle_hex_escape(RakLexer *lex, RakString *text, RakError *err)
-{
-  if (!isxdigit(current_char(lex)) || !isxdigit(char_at(lex, 1)))
-  {
-    rak_error_set(
-      err,
-      "expecting two hexadecimal numbers for escape '\\x' at %d,%d", 
-      lex->ln,
-      lex->col
-    );
-    return false;
-  }  
-  unsigned char code = hex2bin(current_char(lex)) * 16 + hex2bin(char_at(lex, 1));
-  if (code > 0x7f)
-  {
-    rak_error_set(
-      err,
-      "escape '\\x' is limited to ascii chars (below 0x7f) at %d,%d", 
-      lex->ln,
-      lex->col
-    );
-    return false;
-  }
-  rak_string_inplace_append_cstr(text, 1, (char *) &code, err);
-  next_chars(lex, 2);
-  return rak_is_ok(err);
-}
-
-static bool handle_escape_sequence(RakLexer *lex, RakString *text, RakError *err)
-{
-  switch (current_char(lex)) {
-  case 'n':
-    rak_string_inplace_append_cstr(text, 1, "\n", err);
-    break;
-  case 'r':
-    rak_string_inplace_append_cstr(text, 1, "\r", err);
-    break;
-  case 't':
-    rak_string_inplace_append_cstr(text, 1, "\t", err);
-    break;
-  case '"':
-    rak_string_inplace_append_cstr(text, 1, "\"", err);
-    break;
-  case '\\':
-    rak_string_inplace_append_cstr(text, 1, "\\", err);
-    break;
-  case '0':
-    rak_string_inplace_append_cstr(text, 1, "\0", err);
-    break;
-  case 'x':
-    next_char(lex);
-    return handle_hex_escape(lex, text, err);
-  default:
-    rak_error_set(
-      err,
-      "unknown escape sequence '\\%c' at %d,%d", 
-      isprint(current_char(lex)) ? current_char(lex) : '?', 
-      lex->ln,
-      lex->col
-    );
-    return false;
-  }
-  next_char(lex);
-  return rak_is_ok(err);
-}
-
-static bool parse_string(RakLexer *lex, RakError *err)
-{
-  RakString *text = rak_string_new(err);
-  if (!rak_is_ok(err)) return false;
+  bool isEscape = false;
+  char *cstrStart = lex->curr;
   while (true)
   {
     switch (current_char(lex))
@@ -238,23 +158,26 @@ static bool parse_string(RakLexer *lex, RakError *err)
     case '\0':
     case '\n':
       rak_error_set(err, "unterminated string at %d,%d", lex->ln, lex->col);
-      break;
+      return;
     case '\"':
-      lex->tok = token(lex, RAK_TOKEN_KIND_STRING, rak_string_len(text), rak_string_chars(text));
+      if (isEscape)
+      {
+        isEscape = false;
+        next_char(lex);
+        continue;
+      }
+      lex->tok = token(lex, RAK_TOKEN_KIND_STRING, (int)(lex->curr - cstrStart), cstrStart);
       next_char(lex);
-      return true;
+      return;
     case '\\':
+      isEscape = true;
       next_char(lex);
-      if (!handle_escape_sequence(lex, text, err)) break;
       continue;
     default:
-      rak_string_inplace_append_cstr(text, 1, &current_char(lex), err);
-      if (!rak_is_ok(err)) break;
+      isEscape = false;
       next_char(lex);
       continue;
     }
-    rak_string_free(text);
-    return false;
   }
 }
 
@@ -262,7 +185,8 @@ static inline bool match_string(RakLexer *lex, RakError *err)
 {
   if (current_char(lex) != '\"') return false;
   next_char(lex);
-  return parse_string(lex, err);
+  check_string(lex, err);
+  return true;
 }
 
 static inline bool match_keyword(RakLexer *lex, const char *kw, RakTokenKind kind)

--- a/tests/strings.yaml
+++ b/tests/strings.yaml
@@ -56,7 +56,7 @@
 - test: Wrong hex escape (3)
   source: 'println("a\x4'
   out:
-    regex: "expecting two hexadecimal numbers"
+    regex: "unterminated string"
   exit_code: 1
 
 - test: String over 4k


### PR DESCRIPTION
Solving also one memory leak.

Now lexer `match_string` only checks if string is valid and get its length. The escaping is done in an appropriate function in `string.c`, generating a RakString at `compile.c` function.

Additionally, it is not included, but `rak_lexer_init` does not need to check error after `match_string`.